### PR TITLE
Fixed “Unexpected UTF-8 BOM” error when using encode_wfeditor

### DIFF
--- a/wfeditor/parser.py
+++ b/wfeditor/parser.py
@@ -28,7 +28,7 @@ class WFEditorParser:
         self.folder = Path(src)
 
         with open(self.folder / "watchface.json", "r") as f:
-            self.data = json.loads(f.read())
+            self.data = json.loads(f.read().encode().decode('utf-8-sig'))
 
         self.parse()
 


### PR DESCRIPTION
When trying to compile a watchface file for Redmi Watch 2 lite created in WatchfaceEditor, the script crashed with the error `JSONDecodeError("Unexpected UTF-8 BOM (decode using utf-8-sig)`.

The error was solved by adding `.encode().decode('utf-8-sig')` to the line https://github.com/Mino260806/miwtool/blob/557bf03bbd6427b62b42132b7cc031aa52ad95bb/wfeditor/parser.py#L31
![error_screenshot](https://github.com/Mino260806/miwtool/assets/59145732/613dda8f-4fe0-4b2e-8dd1-2aa8f9a60765)
